### PR TITLE
fix/Fix error calculating usage when not provided

### DIFF
--- a/custom_components/unraid_api/sensor.py
+++ b/custom_components/unraid_api/sensor.py
@@ -68,7 +68,7 @@ def calc_ram_usage_percentage(coordinator: UnraidDataUpdateCoordinator) -> State
 def calc_disk_usage_percentage(disk: Disk) -> StateType:
     """Calculate the disk usage percentage."""
     if disk.fs_used is None or disk.fs_size is None or disk.fs_size == 0:
-        return 0
+        return None
     return (disk.fs_used / disk.fs_size) * 100
 
 


### PR DESCRIPTION
Fixes https://github.com/chris-mc1/unraid_api/issues/6

Unsure if it's just on the mirrored cache disk, but when UnraidAPI doesn't provide `fsUsed` and `fsSize` values, the plugin errors and stops updating values.

Example API response:
```json
                {
                    "name": "cache2",
                    "status": "DISK_OK",
                    "temp": 48,
                    "fsSize": null,
                    "fsFree": null,
                    "fsUsed": null,
                    "type": "CACHE",
                    "id": "Redacted"
                }
```