### PR TITLE
Change ups_runtime unit from seconds to minutes

### DIFF
--- a/custom_components/unraid_api/sensor.py
+++ b/custom_components/unraid_api/sensor.py
@@ -284,8 +284,7 @@ UPS_SENSOR_DESCRIPTIONS: tuple[UnraidUpsSensorEntityDescription, ...] = (
     UnraidUpsSensorEntityDescription(
         key="ups_runtime",
         device_class=SensorDeviceClass.DURATION,
-        native_unit_of_measurement=UnitOfTime.SECONDS,
-        suggested_unit_of_measurement=UnitOfTime.MINUTES,
+        native_unit_of_measurement=UnitOfTime.MINUTES,
         value_fn=lambda device: device.battery_runtime,
     ),
     UnraidUpsSensorEntityDescription(


### PR DESCRIPTION
This affects APC units such as the Back-UPS BX1300G.
- Fix to show minutes instead of seconds.